### PR TITLE
Fix critical leak in AndroidSQLiteEngine.

### DIFF
--- a/torch-android/src/main/java/org/brightify/torch/android/AndroidSQLiteEngine.java
+++ b/torch-android/src/main/java/org/brightify/torch/android/AndroidSQLiteEngine.java
@@ -243,11 +243,15 @@ public class AndroidSQLiteEngine implements DatabaseEngine {
     public <ENTITY> ENTITY first(LoadQuery<ENTITY> query) {
         CursorIterator<ENTITY> iterator = new CursorIterator<ENTITY>(torchFactory, query, runQuery(query, false));
 
-        if (!iterator.hasNext()) {
-            return null;
-        }
+        try {
+            if (!iterator.hasNext()) {
+                return null;
+            }
+            return iterator.next();
 
-        return iterator.next();
+        } finally {
+            iterator.close();
+        }
     }
 
     @Override

--- a/torch-android/src/main/java/org/brightify/torch/android/CursorIterator.java
+++ b/torch-android/src/main/java/org/brightify/torch/android/CursorIterator.java
@@ -29,6 +29,15 @@ public class CursorIterator<ENTITY> implements Iterator<ENTITY> {
         }
     }
 
+    public boolean close() {
+        if(cursor.isClosed()) {
+            return false;
+        } else {
+            cursor.close();
+            return true;
+        }
+    }
+
     @Override
     public boolean hasNext() { // this goes forever when there is no data!
         return !cursor.isClosed();

--- a/torch-core/src/main/java/org/brightify/torch/action/load/LoaderImpl.java
+++ b/torch-core/src/main/java/org/brightify/torch/action/load/LoaderImpl.java
@@ -200,7 +200,12 @@ public class LoaderImpl<ENTITY> implements
 
     @Override
     public ENTITY id(long id) {
-        return ids(Collections.singleton(id)).iterator().next();
+        List<ENTITY> entities = ids(Collections.singleton(id));
+        if(entities.size() == 0) {
+            return null;
+        } else {
+            return entities.get(0);
+        }
     }
 
     @Override

--- a/torch-core/src/test/java/org/brightify/torch/action/load/LoaderTest.java
+++ b/torch-core/src/test/java/org/brightify/torch/action/load/LoaderTest.java
@@ -20,6 +20,7 @@ import static org.brightify.torch.TorchService.torch;
 import static org.brightify.torch.test.TestUtils.createTestObject;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -86,6 +87,12 @@ public class LoaderTest {
         assertThat(objects.size(), is(2));
         assertThat(objects.get(0), is(testObject2));
         assertThat(objects.get(1), is(testObject3));
+    }
+
+    @Test
+    public void loadByInvalidIdReturnsNull() {
+        TestObject object = torch().load().type(TestObject.class).id(-1000);
+        assertThat(object, is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
The cursor was left open when using `#first()` and there were more than
one entities in the result.
